### PR TITLE
RFC: switch to same llvm_rc label as rest of LLVM stack

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -3,7 +3,7 @@ cdt_name:
 channel_sources:
 - conda-forge/label/llvm_rc,conda-forge
 channel_targets:
-- conda-forge mlir_rc
+- conda-forge llvm_rc
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -7,7 +7,7 @@ cdt_name:
 channel_sources:
 - conda-forge/label/llvm_rc,conda-forge
 channel_targets:
-- conda-forge mlir_rc
+- conda-forge llvm_rc
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -3,7 +3,7 @@ cdt_name:
 channel_sources:
 - conda-forge/label/llvm_rc,conda-forge
 channel_targets:
-- conda-forge mlir_rc
+- conda-forge llvm_rc
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 channel_sources:
 - conda-forge/label/llvm_rc,conda-forge
 channel_targets:
-- conda-forge mlir_rc
+- conda-forge llvm_rc
 cxx_compiler:
 - clangxx
 cxx_compiler_version:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 channel_sources:
 - conda-forge/label/llvm_rc,conda-forge
 channel_targets:
-- conda-forge mlir_rc
+- conda-forge llvm_rc
 cxx_compiler:
 - clang_bootstrap
 cxx_compiler_version:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,7 +1,7 @@
 channel_sources:
 - conda-forge/label/llvm_rc,conda-forge
 channel_targets:
-- conda-forge mlir_rc
+- conda-forge llvm_rc
 cxx_compiler:
 - vs2019
 target_platform:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -4,6 +4,6 @@ cxx_compiler:       # [osx and arm64]
   - clang_bootstrap # [osx and arm64]
 
 channel_targets:
-  - conda-forge mlir_rc
+  - conda-forge llvm_rc
 channel_sources:
   - conda-forge/label/llvm_rc,conda-forge


### PR DESCRIPTION
Not sure why this got a different label in the first place @xhochy?

AFAICT that separation isn't necessary anymore? Or do we really need to publish dev-versions of MLIR against non-rc versions of LLVM?