### PR TITLE
[dev] mlir 19.0.0.dev0, take 2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,14 +12,14 @@ package:
 
 source:
   # - url: https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-{{ version.replace(".rc", "-rc") }}.tar.gz
-  - url: https://github.com/llvm/llvm-project/archive/1754651dd150139d64cdae190afe1faabf69a403.tar.gz
-    sha256: e69a1b15a7972a72334229d597b78ee56a5ed16aa62299df23ecd239dfd3a8f5
+  - url: https://github.com/llvm/llvm-project/archive/edf5782f1780f480c3ae3fc0a44bf5432f9aa48b.tar.gz
+    sha256: 34129ca709be4fcc1cf3ae5565cb4ed93e497594923f32603e545aa5cd57bb7b
     patches:
       # https://reviews.llvm.org/D99470
       - patches/0001-Support-cross-compiling-standalone-MLIR.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,10 +11,9 @@ package:
   version: {{ version }}
 
 source:
-  - git_url: https://github.com/llvm/llvm-project.git
-    git_rev: 1754651dd150139d64cdae190afe1faabf69a403
   # - url: https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-{{ version.replace(".rc", "-rc") }}.tar.gz
-  #   sha256: b60df7cbe02cef2523f7357120fb0d46cbb443791cde3a5fb36b82c335c0afc9
+  - url: https://github.com/llvm/llvm-project/archive/1754651dd150139d64cdae190afe1faabf69a403.tar.gz
+    sha256: e69a1b15a7972a72334229d597b78ee56a5ed16aa62299df23ecd239dfd3a8f5
     patches:
       # https://reviews.llvm.org/D99470
       - patches/0001-Support-cross-compiling-standalone-MLIR.patch


### PR DESCRIPTION
Rebuild again from main (https://github.com/llvm/llvm-project/commit/edf5782f1780f480c3ae3fc0a44bf5432f9aa48b) after fix for flang (https://github.com/llvm/llvm-project/commit/a2d340ba161fe48ee4ff736c6e7877038a7388cd) landed upstream