### PR TITLE
[dev] mlir 19.0.0.dev0, take 3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,14 +12,14 @@ package:
 
 source:
   # - url: https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-{{ version.replace(".rc", "-rc") }}.tar.gz
-  - url: https://github.com/llvm/llvm-project/archive/edf5782f1780f480c3ae3fc0a44bf5432f9aa48b.tar.gz
-    sha256: 34129ca709be4fcc1cf3ae5565cb4ed93e497594923f32603e545aa5cd57bb7b
+  - url: https://github.com/llvm/llvm-project/archive/3bb25636414ee5b5eaf99c0bdcc191052c9d7ffb.tar.gz
+    sha256: 72bb3117472025b4e6a6fd6b04041abc735fedbe7f023e56c0413c0cfeb3ca0c
     patches:
       # https://reviews.llvm.org/D99470
       - patches/0001-Support-cross-compiling-standalone-MLIR.patch
 
 build:
-  number: 1
+  number: 3
 
 requirements:
   build:


### PR DESCRIPTION
Jump to `_3` is intentional, as some other 19.0.0.dev0 builds are on `_2` already.